### PR TITLE
Update to Factorio 0.17

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -1,15 +1,2 @@
-require("prototypes.item")
 require("prototypes.statictext")
-
-data:extend({
-  {
-      type = "custom-input",
-      name = "toggle-utilization-monitor",
-      key_sequence = "CONTROL + SHIFT + U"
-  },
-  {
-      type = "custom-input",
-      name = "toggle-utilization-monitor-labels",
-      key_sequence = "CONTROL + U"
-  }
-})
+require("prototypes.inputs")

--- a/info.json
+++ b/info.json
@@ -1,11 +1,10 @@
 {
     "name": "UtilizationMonitor",
-    "version": "0.4.1",
+    "version": "0.5.0",
     "title": "Utilization Monitor",
     "author": "Andras Suller",
     "contact": "suller.andras@gmail.com",
     "homepage": "",
-    "factorio_version": "0.16",
-    "dependencies": ["base >= 0.15"],
+    "factorio_version": "0.17",
     "description": "Displays utilization of factories, miners, labs and furnaces."
 }

--- a/prototypes/inputs.lua
+++ b/prototypes/inputs.lua
@@ -1,0 +1,12 @@
+data:extend({
+  {
+    type = "custom-input",
+    name = "toggle-utilization-monitor",
+    key_sequence = "CONTROL + SHIFT + U"
+  },
+  {
+    type = "custom-input",
+    name = "toggle-utilization-monitor-labels",
+    key_sequence = "CONTROL + U"
+  }
+})


### PR DESCRIPTION
The update to factorio is pretty straight forward (`info.json` only).

I removed the empty item prototypes and move the control prototypes to their own file.
Feel free to dismiss the unrelated changes.